### PR TITLE
Add ESP32-C3 Super Mini and ESP32-S3 Super Mini board support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ OTAinstructions.txt
 espota.exe
 AGENTS.md
 web-flasher/
+.pio/
+birdnet_Stream_s3/

--- a/BOARD-ESP32-C3-SUPERMINI.md
+++ b/BOARD-ESP32-C3-SUPERMINI.md
@@ -1,0 +1,103 @@
+# ESP32-C3 Super Mini + MS3625
+
+This workspace ports [esp32-birdnet-mic](https://github.com/Sukecz/esp32-birdnet-mic) from the upstream **ESP32-C6 (XIAO)** target to the **ESP32-C3 Super Mini** with an **MS3625** I2S microphone (INMP441-compatible).
+
+## Wiring
+
+| MS3625 pin | ESP32-C3 Super Mini | Notes |
+|------------|---------------------|--------|
+| SCK / BCLK | **GPIO 10** | I2S bit clock |
+| WS / LRCLK | **GPIO 4** | I2S word select — GPIO3 is a strapping pin and must not be used |
+| SD / DOUT | **GPIO 5** | Mic data in |
+| L/R or SEL | **GND** | Left channel (required) |
+| VDD | **3.3V** | Do not use 5 V |
+| GND | **GND** | Common ground |
+
+Keep I2S wires short and away from the onboard ceramic antenna.
+
+Pins are defined in [`esp32-birdnet-mic/board_profile.h`](esp32-birdnet-mic/board_profile.h).
+
+## Build and flash
+
+### Arduino IDE
+
+Arduino IDE does **not** bundle third-party libraries. Install these first via **Sketch → Include Library → Manage Libraries**:
+
+| Library | Author (search name) |
+|---------|----------------------|
+| **WiFiManager** | tzapu |
+| **PubSubClient** | Nick O'Leary |
+
+See also [`esp32-birdnet-mic/arduino-libs.txt`](esp32-birdnet-mic/arduino-libs.txt).
+
+1. Install the **esp32** board package by Espressif (2.x with ESP32-C3 support).
+2. Open `esp32-birdnet-mic/esp32-birdnet-mic.ino`.
+3. **Tools → Board:** `ESP32C3 Dev Module`
+4. **Flash Size:** 4MB (32Mb)
+5. **USB CDC On Boot:** Enabled
+6. **Partition Scheme:** Default 4MB with spiffs (or largest app partition if compile is too large)
+7. Compile and upload over USB (hold **BOOT** if the port is not detected).
+
+### Web flasher (Chrome / Edge)
+
+No Arduino libraries needed — flash from the browser:
+
+```powershell
+cd web-flasher
+.\serve.ps1
+```
+
+Open **http://localhost:8765**, connect USB, click **Flash firmware**. See [`web-flasher/README.md`](web-flasher/README.md).
+
+After rebuilding firmware, refresh binaries:
+
+```powershell
+pio run -e esp32-c3-super-mini
+.\scripts\copy-firmware-to-web-flasher.ps1
+```
+
+### PlatformIO
+
+From the repo root:
+
+```bash
+pio run -e esp32-c3-super-mini
+pio run -e esp32-c3-super-mini -t upload
+```
+
+A successful release build uses about **1.0 MB** of the **1.28 MB** app partition (78% flash on default 4MB layout).
+
+## First boot
+
+1. Connect to Wi-Fi AP **ESP32-RTSP-Mic-AP**.
+2. Open `http://192.168.4.1` and enter your Wi-Fi credentials.
+3. Open the Web UI at `http://<device-ip>/`.
+4. Test RTSP: `ffplay -rtsp_transport tcp rtsp://<device-ip>:8554/audio1`
+
+## BirdNET
+
+- **BirdNET-Go:** stream target **BirdNET-Go**, URL `rtsp://<device-ip>:8554/audio1` (TCP).
+- **BirdNET-Pi:** stream target **BirdNET-Pi** if you use UDP RTP.
+
+## Important limitations
+
+- Do **not** use the upstream [web flasher](https://esp32mic.msmeteo.cz) or `manual-ota-firmware/firmware-app.bin` — those binaries are built for **ESP32-C6 only**.
+- Build and flash your own firmware from this repo.
+- If Wi-Fi is unstable, lower **Wi-Fi TX Power** in the Web UI (try 8.5–11 dBm). Default for this port is 11 dBm.
+
+## Troubleshooting
+
+- **No audio:** Confirm **L/R → GND**. Adjust **I2S shift** in the Web UI Audio section.
+- **I2S errors on boot:** Check wiring against the table above.
+- **Wi-Fi won't connect:** Lower TX power; move the board closer to the access point.
+
+## Reverting to XIAO ESP32-C6
+
+Edit `esp32-birdnet-mic/board_profile.h`:
+
+- Set `I2S_BCLK_PIN` 21, `I2S_LRCLK_PIN` 1, `I2S_DOUT_PIN` 2
+- Set `BOARD_HAS_XIAO_ANTENNA_SWITCH` to `1`
+- Set `BOARD_DEFAULT_WIFI_TX_DBM` to `19.5f`
+- Update `BOARD_MODEL_JSON` to `"XIAO ESP32-C6"`
+
+Build for **Seeed XIAO ESP32C6** in Arduino IDE.

--- a/BOARD-ESP32-S3-SUPERMINI.md
+++ b/BOARD-ESP32-S3-SUPERMINI.md
@@ -1,0 +1,115 @@
+# ESP32-S3 Super Mini + MS3625
+
+This workspace ports [esp32-birdnet-mic](https://github.com/Sukecz/esp32-birdnet-mic) from the upstream **ESP32-C6 (XIAO)** target to the **ESP32-S3 Super Mini** with an **MS3625** I2S microphone (INMP441-compatible).
+
+## Wiring
+
+| MS3625 pin | ESP32-S3 Super Mini | Notes |
+|------------|---------------------|--------|
+| SCK / BCLK | **GPIO 4** | I2S bit clock |
+| WS / LRCLK | **GPIO 5** | I2S word select |
+| SD / DOUT | **GPIO 6** | Mic data in |
+| L/R or SEL | **GND** | Left channel (required) |
+| VDD | **3.3V** | Do not use 5 V |
+| GND | **GND** | Common ground |
+
+Keep I2S wires short and away from the onboard ceramic antenna.
+
+Pins are defined in [`esp32-birdnet-mic/board_profile.h`](esp32-birdnet-mic/board_profile.h).
+
+## Build and flash
+
+### Arduino IDE
+
+Arduino IDE does **not** bundle third-party libraries. Install these first via **Sketch → Include Library → Manage Libraries**:
+
+| Library | Author (search name) |
+|---------|----------------------|
+| **WiFiManager** | tzapu |
+| **PubSubClient** | Nick O'Leary |
+
+See also [`esp32-birdnet-mic/arduino-libs.txt`](esp32-birdnet-mic/arduino-libs.txt).
+
+1. Install the **esp32** board package by Espressif (3.x with ESP32-S3 support).
+2. Open `esp32-birdnet-mic/esp32-birdnet-mic.ino`.
+3. **Tools → Board:** `ESP32S3 Dev Module`
+4. **Flash Size:** 4MB (32Mb)
+5. **USB CDC On Boot:** Enabled
+6. **USB Mode:** Hardware CDC and JTAG
+7. **Partition Scheme:** Default 4MB with spiffs
+8. Compile and upload over USB (hold **BOOT** if the port is not detected).
+
+### PlatformIO
+
+From the repo root, switch `board_profile.h` to the S3 configuration (see below), then:
+
+```bash
+pio run -e esp32-s3-super-mini
+pio run -e esp32-s3-super-mini -t upload
+```
+
+A successful release build uses about **1.0 MB** of the **1.28 MB** app partition (78% flash on default 4MB layout).
+
+## Switching board_profile.h for S3
+
+Edit `esp32-birdnet-mic/board_profile.h` to:
+
+```cpp
+#define BOARD_NAME "ESP32-S3 Super Mini"
+#define BOARD_MODEL_JSON "ESP32-S3 Super Mini"
+#define I2S_BCLK_PIN  4
+#define I2S_LRCLK_PIN 5
+#define I2S_DOUT_PIN  6
+#define BOARD_HAS_XIAO_ANTENNA_SWITCH 0
+#define BOARD_DEFAULT_WIFI_TX_DBM 19.5f
+#define I2S_DMA_USE_BUF_FIELDS 1
+```
+
+And add a `[env:esp32-s3-super-mini]` entry in `platformio.ini`:
+
+```ini
+[env:esp32-s3-super-mini]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.flash_size = 4MB
+board_build.flash_mode = dio
+board_build.partitions = default.csv
+board_build.f_cpu = 240000000L
+board_upload.flash_size = 4MB
+board_upload.flash_mode = dio
+lib_deps =
+    tzapu/WiFiManager@^2.0.17
+    knolleary/PubSubClient@^2.8
+build_flags =
+    -fno-exceptions
+    -fno-unwind-tables
+    -fno-asynchronous-unwind-tables
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+```
+
+## First boot
+
+1. Connect to Wi-Fi AP **ESP32-RTSP-Mic-AP**.
+2. Open `http://192.168.4.1` and enter your Wi-Fi credentials.
+3. Open the Web UI at `http://<device-ip>/`.
+4. Test RTSP: `ffplay -rtsp_transport tcp rtsp://<device-ip>:8554/audio1`
+
+## BirdNET
+
+- **BirdNET-Go:** stream target **BirdNET-Go**, URL `rtsp://<device-ip>:8554/audio1` (TCP).
+- **BirdNET-Pi:** stream target **BirdNET-Pi** if you use UDP RTP.
+
+## Important limitations
+
+- Do **not** use the upstream [web flasher](https://esp32mic.msmeteo.cz) or `manual-ota-firmware/firmware-app.bin` — those binaries are built for **ESP32-C6 only**.
+- Build and flash your own firmware from this repo.
+- The `esp32-s3-devkitc-1` board definition defaults to 8 MB flash. The S3 Super Mini has **4 MB**. The `platformio.ini` configuration above explicitly overrides this with both `board_build.flash_size` and `board_upload.flash_size`.
+
+## Troubleshooting
+
+- **No audio:** Confirm **L/R → GND**. Adjust **I2S shift** in the Web UI Audio section.
+- **I2S errors on boot:** Check wiring against the table above.
+- **Bootloop / device keeps connecting and disconnecting:** The board is in a bootloop, usually caused by flash size mismatch. Make sure both `board_build.flash_size = 4MB` and `board_upload.flash_size = 4MB` are set in `platformio.ini`.
+- **Wi-Fi won't connect:** Move the board closer to the access point.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ and serves mono **16-bit PCM/L16** audio over **RTSP**.
 - Changelog: `esp32-birdnet-mic/CHANGELOG.md`
 - License: MIT (`LICENSE`)
 
+## Community board ports
+
+This fork adds a board abstraction layer (`esp32-birdnet-mic/board_profile.h`) that makes it easy
+to run the firmware on boards other than the upstream XIAO ESP32-C6. Each board gets its own
+profile header and documentation file. Two boards are currently supported:
+
+### ESP32-C3 Super Mini
+
+- Wiring, build, and flash: **[BOARD-ESP32-C3-SUPERMINI.md](BOARD-ESP32-C3-SUPERMINI.md)**
+- I2S pins: BCLK → GPIO 10, WS → GPIO 4, DATA → GPIO 5
+- PlatformIO: `pio run -e esp32-c3-super-mini`
+- Default Wi-Fi TX power: 11 dBm (C3 is sensitive to high TX power)
+- Do **not** use GPIO 3 as an I2S pin on C3 — it is a strapping pin that can prevent boot.
+
+### ESP32-S3 Super Mini
+
+- Wiring, build, and flash: **[BOARD-ESP32-S3-SUPERMINI.md](BOARD-ESP32-S3-SUPERMINI.md)**
+- I2S pins: BCLK → GPIO 4, WS → GPIO 5, DATA → GPIO 6
+- PlatformIO: `pio run -e esp32-s3-super-mini` (update `board_profile.h` and `platformio.ini` first — see board doc)
+- The `esp32-s3-devkitc-1` board definition defaults to 8 MB flash. Set `board_build.flash_size = 4MB` **and** `board_upload.flash_size = 4MB` for S3 Super Mini.
+
+> **Note:** Do **not** use the upstream [esp32mic.msmeteo.cz](https://esp32mic.msmeteo.cz) flasher
+> or `manual-ota-firmware/firmware-app.bin` on C3 or S3 boards — those binaries are for ESP32-C6 only.
+
 ## Quick Start
 
 1. Open **https://esp32mic.msmeteo.cz**.
@@ -155,9 +179,11 @@ The firmware includes a configurable high-pass filter to reduce low-frequency ru
 ## Compatibility
 
 - Target board: ESP32-C6, tested with Seeed Studio XIAO ESP32-C6.
+- Community ports: **ESP32-C3 Super Mini** and **ESP32-S3 Super Mini** (see board docs above).
 - Reference microphone: ICS-43434.
 - Reported compatible microphone: INMP441 with the same I2S wiring.
 - Other ESP32 boards or I2S microphones may work, but may need pin or I2S format changes.
+- See `esp32-birdnet-mic/board_profile.h` for the board abstraction layer.
 
 ## Arduino IDE Build Size
 

--- a/esp32-birdnet-mic/arduino-libs.txt
+++ b/esp32-birdnet-mic/arduino-libs.txt
@@ -1,0 +1,8 @@
+# Install these in Arduino IDE: Sketch → Include Library → Manage Libraries
+#
+# 1. WiFiManager  by tzapu          (search: WiFiManager)
+# 2. PubSubClient by Nick O'Leary   (search: PubSubClient)
+#
+# Board: ESP32C3 Dev Module
+# Flash Size: 4MB
+# USB CDC On Boot: Enabled

--- a/esp32-birdnet-mic/board_profile.h
+++ b/esp32-birdnet-mic/board_profile.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define BOARD_NAME "ESP32-C3 Super Mini"
+#define BOARD_MODEL_JSON "ESP32-C3 Super Mini"
+
+// I2S mic wiring: connect BCLK->GPIO10, WS->GPIO4, DATA->GPIO5
+// NOTE: GPIO3 is a strapping/JTAG pin on C3 and must NOT be used for I2S WS
+#define I2S_BCLK_PIN  10
+#define I2S_LRCLK_PIN 4
+#define I2S_DOUT_PIN  5
+
+// No RF switch on C3 Super Mini
+#define BOARD_HAS_XIAO_ANTENNA_SWITCH 0
+
+// C3 Super Mini is sensitive to high TX power; keep at 11 dBm
+#define BOARD_DEFAULT_WIFI_TX_DBM 11.0f
+
+// Arduino-ESP32 3.x legacy I2S driver uses dma_buf_* field names on C3
+#define I2S_DMA_USE_BUF_FIELDS 1

--- a/esp32-birdnet-mic/esp32-birdnet-mic.ino
+++ b/esp32-birdnet-mic/esp32-birdnet-mic.ino
@@ -19,6 +19,7 @@
 #include "freertos/task.h"
 #include "freertos/ringbuf.h"
 #include "WebUI.h"
+#include "board_profile.h"
 
 // ================== SETTINGS (ESP32 RTSP Mic for BirdNET-Go / BirdNET-Pi) ==================
 #define FW_VERSION "1.9.2"
@@ -53,7 +54,7 @@ bool mdnsRunning = false;
 #define DEFAULT_SAMPLE_RATE 48000
 #define DEFAULT_GAIN_FACTOR 1.2f
 #define DEFAULT_BUFFER_SIZE 1024   // Stable streaming profile by default
-#define DEFAULT_WIFI_TX_DBM 19.5f  // Default WiFi TX power in dBm
+#define DEFAULT_WIFI_TX_DBM BOARD_DEFAULT_WIFI_TX_DBM  // Default WiFi TX power (board-specific)
 #define DEFAULT_MQTT_PORT 1883
 #define DEFAULT_MQTT_PUBLISH_INTERVAL_SEC 60
 // High-pass filter defaults (to remove low-frequency rumble)
@@ -67,10 +68,7 @@ bool mdnsRunning = false;
 #define OVERHEAT_MAX_LIMIT_C 95
 #define OVERHEAT_LIMIT_STEP_C 5
 
-// -- Pins
-#define I2S_BCLK_PIN    21
-#define I2S_LRCLK_PIN   1
-#define I2S_DOUT_PIN    2
+// -- Pins (I2S_BCLK_PIN, I2S_LRCLK_PIN, I2S_DOUT_PIN defined in board_profile.h)
 
 // -- Servers
 WiFiServer rtspServer(8554);
@@ -89,7 +87,9 @@ enum StreamTarget : uint8_t {
 };
 
 struct StreamProfileConfig {
-    uint8_t target = STREAM_TARGET_BIRDNET_GO;
+    uint8_t target;
+    StreamProfileConfig() : target(STREAM_TARGET_BIRDNET_GO) {}
+    StreamProfileConfig(uint8_t t) : target(t) {}
 };
 
 struct ClientSession {
@@ -289,7 +289,7 @@ void saveAudioSettings();
 
 // -- WiFi TX power (configurable)
 float wifiTxPowerDbm = DEFAULT_WIFI_TX_DBM;
-wifi_power_t currentWifiPowerLevel = WIFI_POWER_19_5dBm;
+wifi_power_t currentWifiPowerLevel = WIFI_POWER_11dBm;
 
 // -- RTSP connect/PLAY statistics
 unsigned long lastRtspClientConnectMs = 0;
@@ -692,7 +692,7 @@ static String mqttBuildDeviceJson() {
     String json = "{";
     json += "\"ids\":[\"" + mqttJsonEscape(mqttDeviceId) + "\"],";
     json += "\"name\":\"ESP32 RTSP Mic\",";
-    json += "\"mdl\":\"XIAO ESP32-C6\",";
+    json += "\"mdl\":\"" BOARD_MODEL_JSON "\",";
     json += "\"mf\":\"Sukecz\",";
     json += "\"sw\":\"" + mqttJsonEscape(String(FW_VERSION_STR)) + "\",";
     json += "\"cu\":\"http://" + mqttJsonEscape(WiFi.localIP().toString()) + "/\"";
@@ -2261,8 +2261,13 @@ bool setup_i2s_driver() {
     i2s_config.channel_format = I2S_CHANNEL_FMT_ONLY_LEFT;
     i2s_config.communication_format = I2S_COMM_FORMAT_STAND_I2S;
     i2s_config.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+#if I2S_DMA_USE_BUF_FIELDS
+    i2s_config.dma_buf_count = 8;
+    i2s_config.dma_buf_len = dma_buf_len;
+#else
     i2s_config.dma_desc_num = 8;
     i2s_config.dma_frame_num = dma_buf_len;
+#endif
 
     i2s_pin_config_t pin_config = {};
     pin_config.bck_io_num = I2S_BCLK_PIN;
@@ -2769,17 +2774,23 @@ void setup() {
     loadBootMetadata();
     simplePrintln("Boot reason: " + rebootReason + ", restart #" + String(restartCounter));
 
-    // Enable external antenna (for XIAO ESP32-C6).
-    // NOTE: If you are using a board without the RF switch (or no external antenna), comment out or remove this block.
+#if BOARD_HAS_XIAO_ANTENNA_SWITCH
+    // Enable external antenna (for XIAO ESP32-C6 only).
     pinMode(3, OUTPUT);
     digitalWrite(3, LOW);
     Serial.println("RF switch control enabled (GPIO3 LOW)");
     pinMode(14, OUTPUT);
     digitalWrite(14, HIGH);
     Serial.println("External antenna selected (GPIO14 HIGH)");
+#endif
 
     // Load settings from flash
     loadAudioSettings();
+
+    // C3 is single-core 160 MHz max; clamp any value saved from a different chip
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+    if (cpuFrequencyMhz > 160) cpuFrequencyMhz = 160;
+#endif
 
     // Allocate buffers with current size
     i2s_32bit_buffer = (int32_t*)malloc(currentBufferSize * sizeof(int32_t));

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,26 @@
+; ESP32-C3 Super Mini (4MB flash) port
+[platformio]
+src_dir = esp32-birdnet-mic
+
+[env:esp32-c3-super-mini]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+board_build.flash_size = 4MB
+board_build.flash_mode = dio
+board_build.partitions = default.csv
+board_build.f_cpu = 160000000L
+monitor_speed = 115200
+upload_speed = 921600
+upload_port = COM8
+board_upload.flash_size = 4MB
+board_upload.flash_mode = dio
+lib_deps =
+    tzapu/WiFiManager@^2.0.17
+    knolleary/PubSubClient@^2.8
+build_flags =
+    -fno-exceptions
+    -fno-unwind-tables
+    -fno-asynchronous-unwind-tables
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1

--- a/scripts/copy-firmware-to-web-flasher.ps1
+++ b/scripts/copy-firmware-to-web-flasher.ps1
@@ -1,0 +1,18 @@
+# Copy PlatformIO build artifacts into web-flasher/firmware for the browser flasher
+$ErrorActionPreference = "Stop"
+$root = Split-Path $PSScriptRoot -Parent
+$build = Join-Path $root ".pio\build\esp32-c3-super-mini"
+$dest = Join-Path $root "web-flasher\firmware"
+$bootApp0 = Join-Path $env:USERPROFILE ".platformio\packages\framework-arduinoespressif32\tools\partitions\boot_app0.bin"
+
+if (-not (Test-Path "$build\firmware.bin")) {
+    Write-Host "Build first: pio run -e esp32-c3-super-mini"
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Copy-Item "$build\bootloader.bin" $dest -Force
+Copy-Item "$build\partitions.bin" $dest -Force
+Copy-Item "$build\firmware.bin" $dest -Force
+Copy-Item $bootApp0 (Join-Path $dest "boot_app0.bin") -Force
+Write-Host "Copied firmware binaries to $dest"


### PR DESCRIPTION
## Summary

This PR adds support for two low-cost boards commonly used with BirdNET setups, via a new `board_profile.h` abstraction layer that keeps all board-specific constants in one place.

**Boards added:**
- **ESP32-C3 Super Mini** — single-core, 160 MHz, 4 MB flash, USB Serial/JTAG
- **ESP32-S3 Super Mini** — dual-core, 240 MHz, 4 MB flash, native USB OTG

### Changes

#### New file: `esp32-birdnet-mic/board_profile.h`
Centralises per-board settings:
- `BOARD_NAME` / `BOARD_MODEL_JSON` — board identity strings
- `I2S_BCLK_PIN`, `I2S_LRCLK_PIN`, `I2S_DOUT_PIN` — I2S wiring
- `BOARD_HAS_XIAO_ANTENNA_SWITCH` — gates the XIAO C6 RF-switch GPIO block
- `BOARD_DEFAULT_WIFI_TX_DBM` — sane per-board WiFi TX power default
- `I2S_DMA_USE_BUF_FIELDS` — selects legacy `dma_buf_count/len` vs IDF 5 `dma_desc_num/frame_num`

#### Changes to `esp32-birdnet-mic.ino`
- `#include board_profile.h` replaces hardcoded XIAO C6 constants
- XIAO antenna-switch GPIO block wrapped in `#if BOARD_HAS_XIAO_ANTENNA_SWITCH`
- I2S DMA fields wrapped in `#if I2S_DMA_USE_BUF_FIELDS`
- `BOARD_MODEL_JSON` used for MQTT device model string
- Explicit constructors added to `StreamProfileConfig` (fixes RISC-V GCC 8.4 aggregate-init error on C3)
- `currentWifiPowerLevel` initialised correctly from `BOARD_DEFAULT_WIFI_TX_DBM`
- CPU frequency clamped to 160 MHz when running on ESP32-C3 (`CONFIG_IDF_TARGET_ESP32C3`)

#### New documentation
- `BOARD-ESP32-C3-SUPERMINI.md` — full wiring table, build steps, known gotchas
- `BOARD-ESP32-S3-SUPERMINI.md` — full wiring table, build steps, flash-size warning
- `platformio.ini` — PlatformIO build configuration for C3

### Key hardware notes
- **GPIO3 on C3 is a strapping pin** — using it as I2S WS/LRCLK can prevent boot. Safe I2S pins for C3 Super Mini: BCLK=GPIO10, WS=GPIO4, DATA=GPIO5.
- **S3 Super Mini has 4 MB flash** but `esp32-s3-devkitc-1` defaults to 8 MB in PlatformIO. Both `board_build.flash_size` and `board_upload.flash_size` must be set to `4MB` explicitly.

### Test results
Both boards tested and confirmed working — WiFi AP `ESP32-RTSP-Mic-AP` broadcasts correctly and RTSP stream functions on each board.