### PR TITLE
Add M5Stack Atom VoiceS3R microphone support

### DIFF
--- a/.github/workflows/arduino-build.yml
+++ b/.github/workflows/arduino-build.yml
@@ -50,3 +50,21 @@ jobs:
       - name: Compile ${{ matrix.name }}
         run: |
           arduino-cli compile --fqbn "${{ matrix.fqbn }}" esp32-birdnet-mic
+
+  compile-voices3r:
+    needs: ota-contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO
+        run: pip install platformio==6.1.19
+
+      - name: Compile M5Stack Atom VoiceS3R
+        run: pio run -e m5stack-atom-voices3r

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ espota.exe
 AGENTS.md
 scripts/
 tmp/
+.pio/
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 # birdnet-esp32-rtsp-mic
 
-Seeed XIAO ESP32 network microphone for **BirdNET-Go** and **BirdNET-Pi**. It reads an I2S MEMS
-microphone and serves mono **16-bit PCM/L16** audio over **RTSP**.
+ESP32 network microphone for **BirdNET-Go** and **BirdNET-Pi**. It reads an I2S MEMS microphone
+and serves mono **16-bit PCM/L16** audio over **RTSP**. In addition to the original Seeed XIAO
+targets, the firmware supports the integrated microphone in the M5Stack Atom VoiceS3R (C126).
 
 - Latest firmware: **v1.22** (2026-08-01)
 - Target sketch: `esp32-birdnet-mic`
@@ -45,9 +46,15 @@ Supported XIAO boards:
 - [Seeed Studio XIAO ESP32-C5](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C5-p-6609.html)
 - [Seeed Studio XIAO ESP32-C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)
 
+Additional runtime-tested board:
+
+- [M5Stack Atom VoiceS3R / EchoS3R (C126)](https://docs.m5stack.com/en/core/Atom_EchoS3R)
+
 Default build notes:
 
 - The web flasher detects the connected ESP chip family and selects the matching firmware.
+- Atom VoiceS3R currently uses the manual PlatformIO build described in the firmware documentation;
+  it is not included in the public web flasher or automatic OTA artifacts yet.
 - XIAO ESP32-C6 external antenna RF switch is enabled by default.
 - XIAO ESP32-C3, XIAO ESP32-S3, and XIAO ESP32-C5 use their U.FL antenna path without firmware GPIO switching.
 - OTA has no password in the default public build. Keep the device on your trusted LAN.
@@ -61,6 +68,9 @@ Default build notes:
 
 Tested build targets: **Seeed Studio XIAO ESP32-C3/S3/C5/C6**. Runtime hardware validation is still
 primarily on **XIAO ESP32-C6** + **ICS-43434** I2S microphone.
+
+The Atom VoiceS3R needs no microphone wiring. Its built-in ES8311 codec and MEMS microphone are
+initialized by the dedicated `m5stack-atom-voices3r` build target.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/connection-dark.png">

--- a/boards/m5stack-atoms3r.json
+++ b/boards/m5stack-atoms3r.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino": {
+      "memory_type": "qio_opi",
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_M5STACK_ATOMS3R",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32s3",
+    "variant": "m5stack_atoms3"
+  },
+  "connectivity": ["bluetooth", "wifi"],
+  "frameworks": ["arduino", "espidf"],
+  "name": "M5Stack Atom VoiceS3R",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.m5stack.com/en/core/Atom_EchoS3R",
+  "vendor": "M5Stack"
+}

--- a/esp32-birdnet-mic/README.md
+++ b/esp32-birdnet-mic/README.md
@@ -4,13 +4,14 @@
 
 # birdnet-esp32-rtsp-mic Firmware
 
-Arduino firmware for Seeed XIAO ESP32 I2S microphones that serve **mono 16-bit PCM/L16** audio over
-**RTSP** for **BirdNET-Go** and **BirdNET-Pi**. It also provides a Web UI, JSON API, MQTT telemetry,
-and Home Assistant MQTT Discovery.
+Arduino firmware for ESP32 I2S microphones that serve **mono 16-bit PCM/L16** audio over **RTSP**
+for **BirdNET-Go** and **BirdNET-Pi**. It also provides a Web UI, JSON API, MQTT telemetry, and Home
+Assistant MQTT Discovery.
 
 - Latest firmware: **v1.22** (2026-08-01)
-- Build targets: Seeed Studio **XIAO ESP32-C3**, **XIAO ESP32-S3**, **XIAO ESP32-C5**, **XIAO ESP32-C6**
-- Runtime-tested board: Seeed Studio **XIAO ESP32-C6**
+- Build targets: Seeed Studio **XIAO ESP32-C3**, **XIAO ESP32-S3**, **XIAO ESP32-C5**, **XIAO ESP32-C6**,
+  and M5Stack **Atom VoiceS3R / EchoS3R (C126)**
+- Runtime-tested boards: Seeed Studio **XIAO ESP32-C6** and M5Stack **Atom VoiceS3R (C126)**
 - Reference microphone: **ICS-43434**; **INMP441** has been reported compatible with the same wiring
 - User-facing overview and wiring: `../README.md`
 - Changelog: `CHANGELOG.md`
@@ -462,11 +463,20 @@ arduino-cli compile --fqbn <BOARD_FQBN> esp32-birdnet-mic
 
 ### PlatformIO
 
-Typical targets are board-specific Arduino environments, for example `env:xiao_esp32c6`:
+The repository includes a tested PlatformIO environment for the Atom VoiceS3R:
 
 ```bash
-pio run -t upload
+pio run -e m5stack-atom-voices3r
+pio run -e m5stack-atom-voices3r -t upload
 ```
+
+The VoiceS3R target configures its built-in ES8311 codec over `Wire1` at 100 kHz and captures the
+left I2S slot at 16 bits. It uses GPIO 45/0 for I2C and GPIO 11/17/3/4 for MCLK/BCLK/WS/microphone
+data, following M5Stack's board definition. No external microphone or wiring is required.
+
+After USB upload, physically unplug the VoiceS3R for a few seconds and reconnect it without holding
+the button. Its native USB/JTAG reset can otherwise leave the ESP32-S3 in ROM download mode even
+after the image was written and verified.
 
 ## Web UI Development
 
@@ -546,8 +556,10 @@ Current validation ranges include `sampleRate=8000..192000` and `bufferSize=256.
 
 - No TLS or built-in user authentication for the Web UI/API.
 - mDNS depends on multicast support in your LAN and often does not work across VLANs, guest networks, or Docker bridge networks.
-- The firmware is primarily runtime-tested on Seeed Studio XIAO ESP32-C6 with ICS-43434; C3/S3/C5
-  builds are compile-verified in Arduino ESP32 core 3.3.8.
+- The firmware is runtime-tested on Seeed Studio XIAO ESP32-C6 with ICS-43434 and M5Stack Atom
+  VoiceS3R with its integrated ES8311 microphone; C3/S3/C5 builds are compile-verified in Arduino
+  ESP32 core 3.3.8.
+- Atom VoiceS3R is not yet included in the public web flasher or automatic OTA release artifacts.
 
 ## Credits
 

--- a/esp32-birdnet-mic/esp32-birdnet-mic.ino
+++ b/esp32-birdnet-mic/esp32-birdnet-mic.ino
@@ -2540,6 +2540,8 @@ bool startAudioProducer() {
 // register sequence is the microphone-enable sequence from M5Stack's
 // M5Unified implementation for this exact board.
 #if defined(M5STACK_ATOM_VOICES3R)
+static bool voiceS3RCodecInitialized = false;
+
 static bool writeEs8311Register(uint8_t reg, uint8_t value) {
     Wire1.beginTransmission(ES8311_I2C_ADDRESS);
     Wire1.write(reg);
@@ -2548,6 +2550,8 @@ static bool writeEs8311Register(uint8_t reg, uint8_t value) {
 }
 
 static bool setupVoiceS3RCodec() {
+    if (voiceS3RCodecInitialized) return true;
+
     Wire1.begin(ES8311_I2C_SDA_PIN, ES8311_I2C_SCL_PIN, 100000);
     static constexpr uint8_t init[][2] = {
         {0x00, 0x80}, // reset / CSM power on
@@ -2555,7 +2559,7 @@ static bool setupVoiceS3RCodec() {
         {0x02, 0x18}, // clock manager: MULT_PRE=3
         {0x0D, 0x01}, // power up analog circuitry
         {0x0E, 0x02}, // enable analog PGA and ADC modulator
-        {0x14, 0x10}, // differential microphone input, minimum PGA gain
+        {0x14, 0x15}, // differential microphone input, 15 dB PGA gain
         {0x17, 0xFF}, // ADC digital volume
         {0x1C, 0x6A}, // bypass EQ and cancel DC offset
     };
@@ -2565,6 +2569,7 @@ static bool setupVoiceS3RCodec() {
             return false;
         }
     }
+    voiceS3RCodecInitialized = true;
     simplePrintln("ES8311 microphone codec ready on I2C address 0x18");
     return true;
 }

--- a/esp32-birdnet-mic/esp32-birdnet-mic.ino
+++ b/esp32-birdnet-mic/esp32-birdnet-mic.ino
@@ -12,6 +12,7 @@
 #include <esp_sleep.h>
 #include <esp_system.h>
 #include <WiFiUdp.h>
+#include <Wire.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include "freertos/FreeRTOS.h"
@@ -26,7 +27,13 @@ const char* FW_VERSION_STR = FW_VERSION;
 // Build timestamp for diagnostics (compile time)
 const char* FW_BUILD_DATE_STR = __DATE__ " " __TIME__;
 
-#if defined(ARDUINO_XIAO_ESP32C3)
+#if defined(M5STACK_ATOM_VOICES3R)
+#define XIAO_BOARD_ID "m5stack-atom-voices3r"
+#define XIAO_BOARD_NAME "M5Stack Atom VoiceS3R (C126)"
+#define XIAO_CHIP_FAMILY "ESP32-S3"
+#define XIAO_OTA_ARTIFACT ""
+#define XIAO_HAS_RF_SWITCH 0
+#elif defined(ARDUINO_XIAO_ESP32C3)
 #define XIAO_BOARD_ID "xiao-esp32c3"
 #define XIAO_BOARD_NAME "XIAO ESP32-C3"
 #define XIAO_CHIP_FAMILY "ESP32-C3"
@@ -89,6 +96,11 @@ bool mdnsRunning = false;
 #define DEFAULT_SAMPLE_RATE 48000
 #define DEFAULT_GAIN_FACTOR 1.5f
 #define DEFAULT_BUFFER_SIZE 512    // Balanced default; safer for BirdNET-Pi UDP than 1024-sample packets
+#if defined(M5STACK_ATOM_VOICES3R)
+#define DEFAULT_I2S_SHIFT_BITS 0
+#else
+#define DEFAULT_I2S_SHIFT_BITS 12
+#endif
 #define DEFAULT_WIFI_TX_DBM 15.0f  // Stable default; higher power adds substantial heat on C6
 #define DEFAULT_MQTT_PORT 1883
 #define DEFAULT_MQTT_PUBLISH_INTERVAL_SEC 60
@@ -107,7 +119,15 @@ static const float OVERHEAT_EMERGENCY_MARGIN_C = 10.0f;
 static const unsigned long TEMPERATURE_CHECK_INTERVAL_MS = 5000UL;
 
 // -- Pins
-#if defined(ARDUINO_XIAO_ESP32C3) || defined(ARDUINO_XIAO_ESP32S3) || \
+#if defined(M5STACK_ATOM_VOICES3R)
+static constexpr int I2S_MCLK_PIN = 11;
+static constexpr int I2S_BCLK_PIN = 17;
+static constexpr int I2S_LRCLK_PIN = 3;
+static constexpr int I2S_DOUT_PIN = 4;
+static constexpr int ES8311_I2C_SDA_PIN = 45;
+static constexpr int ES8311_I2C_SCL_PIN = 0;
+static constexpr uint8_t ES8311_I2C_ADDRESS = 0x18;
+#elif defined(ARDUINO_XIAO_ESP32C3) || defined(ARDUINO_XIAO_ESP32S3) || \
     defined(ARDUINO_XIAO_ESP32C5) || defined(ARDUINO_XIAO_ESP32C6)
 static constexpr int I2S_MCLK_PIN = D7;
 static constexpr int I2S_BCLK_PIN = D3;
@@ -239,7 +259,7 @@ bool rtspServerEnabled = true;
 uint32_t currentSampleRate = DEFAULT_SAMPLE_RATE;
 float currentGainFactor = DEFAULT_GAIN_FACTOR;
 uint16_t currentBufferSize = DEFAULT_BUFFER_SIZE;
-uint8_t i2sShiftBits = 12;  // (1) compile-time default respected on first boot
+uint8_t i2sShiftBits = DEFAULT_I2S_SHIFT_BITS;
 
 // -- Audio metering / clipping diagnostics
 uint16_t lastPeakAbs16 = 0;       // last block peak absolute value (0..32767)
@@ -1937,7 +1957,7 @@ void loadAudioSettings() {
     currentSampleRate = audioPrefs.getUInt("sampleRate", DEFAULT_SAMPLE_RATE);
     currentGainFactor = audioPrefs.getFloat("gainFactor", DEFAULT_GAIN_FACTOR);
     currentBufferSize = audioPrefs.getUShort("bufferSize", DEFAULT_BUFFER_SIZE);
-    // (1) respect compile-time default 12 on first boot
+    // Respect the board-specific compile-time default on first boot.
     i2sShiftBits = audioPrefs.getUChar("shiftBits", i2sShiftBits);
     autoRecoveryEnabled = audioPrefs.getBool("autoRecovery", true);
     scheduledResetEnabled = audioPrefs.getBool("schedReset", false);
@@ -2007,7 +2027,7 @@ void loadAudioSettings() {
         settingsRepaired = true;
     }
     if (i2sShiftBits > 24U) {
-        i2sShiftBits = 12;
+        i2sShiftBits = DEFAULT_I2S_SHIFT_BITS;
         settingsRepaired = true;
     }
     if (resetIntervalHours < 1U || resetIntervalHours > 168U) {
@@ -2189,7 +2209,7 @@ void resetToDefaultSettings() {
     currentSampleRate = DEFAULT_SAMPLE_RATE;
     currentGainFactor = DEFAULT_GAIN_FACTOR;
     currentBufferSize = DEFAULT_BUFFER_SIZE;
-    i2sShiftBits = 12;  // compile-time default respected
+    i2sShiftBits = DEFAULT_I2S_SHIFT_BITS;
 
     autoRecoveryEnabled = true;
     autoThresholdEnabled = true;
@@ -2388,9 +2408,15 @@ void audioProducerTask(void* /*arg*/) {
 
     while (!audioProducerStopRequested) {
         size_t bytesRead = 0;
+#if defined(M5STACK_ATOM_VOICES3R)
+        esp_err_t result = i2s_channel_read(i2s_rx_handle, i2s_16bit_buffer,
+                                            currentBufferSize * sizeof(int16_t),
+                                            &bytesRead, 100);
+#else
         esp_err_t result = i2s_channel_read(i2s_rx_handle, i2s_32bit_buffer,
                                             currentBufferSize * sizeof(int32_t),
                                             &bytesRead, 100);
+#endif
         if (audioProducerStopRequested) break;
 
         if (result != ESP_OK || bytesRead == 0) {
@@ -2399,7 +2425,11 @@ void audioProducerTask(void* /*arg*/) {
             continue;
         }
 
+#if defined(M5STACK_ATOM_VOICES3R)
+        int samplesRead = bytesRead / sizeof(int16_t);
+#else
         int samplesRead = bytesRead / sizeof(int32_t);
+#endif
         if (samplesRead <= 0) continue;
 
         // If HPF params changed dynamically, recompute in the producer context.
@@ -2410,7 +2440,11 @@ void audioProducerTask(void* /*arg*/) {
         bool clipped = false;
         float peakAbs = 0.0f;
         for (int i = 0; i < samplesRead; i++) {
+#if defined(M5STACK_ATOM_VOICES3R)
+            float sample = (float)i2s_16bit_buffer[i];
+#else
             float sample = (float)(i2s_32bit_buffer[i] >> i2sShiftBits);
+#endif
             if (highpassEnabled) sample = hpf.process(sample);
             float amplified = sample * currentGainFactor;
             float aabs = fabsf(amplified);
@@ -2502,6 +2536,40 @@ bool startAudioProducer() {
     return true;
 }
 
+// Atom VoiceS3R/C126 uses an ES8311 analog codec in front of I2S. The
+// register sequence is the microphone-enable sequence from M5Stack's
+// M5Unified implementation for this exact board.
+#if defined(M5STACK_ATOM_VOICES3R)
+static bool writeEs8311Register(uint8_t reg, uint8_t value) {
+    Wire1.beginTransmission(ES8311_I2C_ADDRESS);
+    Wire1.write(reg);
+    Wire1.write(value);
+    return Wire1.endTransmission() == 0;
+}
+
+static bool setupVoiceS3RCodec() {
+    Wire1.begin(ES8311_I2C_SDA_PIN, ES8311_I2C_SCL_PIN, 100000);
+    static constexpr uint8_t init[][2] = {
+        {0x00, 0x80}, // reset / CSM power on
+        {0x01, 0xBA}, // clock manager: MCLK/BCLK relationship
+        {0x02, 0x18}, // clock manager: MULT_PRE=3
+        {0x0D, 0x01}, // power up analog circuitry
+        {0x0E, 0x02}, // enable analog PGA and ADC modulator
+        {0x14, 0x10}, // differential microphone input, minimum PGA gain
+        {0x17, 0xFF}, // ADC digital volume
+        {0x1C, 0x6A}, // bypass EQ and cancel DC offset
+    };
+    for (const auto &entry : init) {
+        if (!writeEs8311Register(entry[0], entry[1])) {
+            simplePrintln("ES8311 write failed at register 0x" + String(entry[0], HEX));
+            return false;
+        }
+    }
+    simplePrintln("ES8311 microphone codec ready on I2C address 0x18");
+    return true;
+}
+#endif
+
 // I2S setup
 bool setup_i2s_driver() {
     stopAudioProducer();
@@ -2525,7 +2593,11 @@ bool setup_i2s_driver() {
 
     i2s_std_config_t std_cfg = {
         .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(currentSampleRate),
+#if defined(M5STACK_ATOM_VOICES3R)
+        .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+#else
         .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_32BIT, I2S_SLOT_MODE_MONO),
+#endif
         .gpio_cfg = {
             .mclk = (gpio_num_t)I2S_MCLK_PIN,
             .bclk = (gpio_num_t)I2S_BCLK_PIN,
@@ -2543,6 +2615,14 @@ bool setup_i2s_driver() {
     // leave D7 unconnected and continue to use the same BCLK/WS/SD wiring.
     std_cfg.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
     std_cfg.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
+
+#if defined(M5STACK_ATOM_VOICES3R)
+    if (!setupVoiceS3RCodec()) {
+        i2s_del_channel(i2s_rx_handle);
+        i2s_rx_handle = nullptr;
+        return false;
+    }
+#endif
 
     err = i2s_channel_init_std_mode(i2s_rx_handle, &std_cfg);
     if (err != ESP_OK) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,14 @@
+[platformio]
+src_dir = esp32-birdnet-mic
+
+[env:m5stack-atom-voices3r]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+board = m5stack-atoms3r
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+build_flags =
+  -DM5STACK_ATOM_VOICES3R=1
+lib_deps =
+  tzapu/WiFiManager @ ^2.0.17
+  knolleary/PubSubClient @ ^2.8


### PR DESCRIPTION
## Summary

- add a PlatformIO board target for the M5Stack Atom VoiceS3R (C126-ECHO)
- initialize its ES8311 codec and capture the built-in microphone as 16-bit mono I2S
- document manual build/flash steps and add CI coverage for the new target

## Validation

- `pio run -e m5stack-atom-voices3r`
- `python3 tests/validate_ota_contract.py`
- runtime-tested on Atom VoiceS3R hardware with BirdNET-Go:
  - RTSP `/audio1`: 48 kHz mono L16
  - 15-second capture completed successfully
  - no I2S errors, ring-buffer drops, or RTSP timeouts observed

The public web flasher and automatic OTA artifacts are intentionally unchanged; this board currently uses the documented manual PlatformIO flow.

Related hardware/codec context: esphome/esphome#18693
